### PR TITLE
Document new `setExclusive` behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This method returns an object that describes what markers were *invalidated* by 
 
 By default, we consider markers to be *inclusive*: that is, splices that start exactly where a marker begins **will not** move its start, and splices that end exactly where a marker ends **will** move its end. With the `setExclusive(markerId, true)` API, these rules can be changed by making the specified marker exclusive.
 
-*Exclusive* markers exhibit a different behavior with respect to splices that overlap one or both the marker's endpoints. In facts, splices that start exactly where a marker begins **will** move its start **only if the marker is not empty or the splice operation is an insertion**. On the other hand, splices that end exactly where a marker ends **will not** move its end.
+*Exclusive* markers exhibit a different behavior with respect to splices that overlap one or both the marker's endpoints. In fact, splices that start exactly where a marker begins **will** move its start **only if the marker is not empty or the splice operation is an insertion**. On the other hand, splices that end exactly where a marker ends **will not** move its end.
 
 A general rule applies to both cases, however: when a marker's start gets moved as a result of a splice, its end **will always** be moved as well.
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@ This method returns an object that describes what markers were *invalidated* by 
 
 ### `setExclusive (markerId, boolean)`
 
-By default, we consider markers to be *inclusive*: that is, splices that start exactly where a marker begins **will not** move its start, and splices that end exactly where a marker ends **will** move its end. With the `setExclusive(markerId, true)` API, these rules can be changed by making the specified marker exclusive.
+This method allows to control the behavior of a marker when splices start and/or end at the marker's endpoints.
 
-*Exclusive* markers exhibit a different behavior with respect to splices that overlap one or both the marker's endpoints. In fact, splices that start exactly where a marker begins **will** move its start **only if the marker is not empty or the splice operation is an insertion**. On the other hand, splices that end exactly where a marker ends **will not** move its end.
+By default, we consider markers to be *inclusive*: that is, splices exactly at the beginning of the marked range will be considered to begin inside the marker (meaning that the marker's start position **will not** move), and splices exactly at the end of the marked range will be considered to end inside the marker (meaning that the marker's end position **will** move). 
 
-A general rule applies to both cases, however: when a marker's start gets moved as a result of a splice, its end **will always** be moved as well.
+*Exclusive* markers, on the other hand, exhibit a slightly different behavior: in fact, splices exactly at the beginning of the marked range will be considered to begin outside the marker (meaning that the marker's start position **will** move), and splices exactly at the end of the marked range will be considered to end outside the marker (meaning that the marker's end position **will not** move).
+
+Please note that, independently of whether a marker is inclusive or exclusive, its end **will always** be moved when its start gets moved as a result of a splice.
 
 ### `isExclusive (markerId)`
 

--- a/README.md
+++ b/README.md
@@ -34,12 +34,14 @@ This method returns an object that describes what markers were *invalidated* by 
 
 * `touch` Contains markers that the change touched in any way.
 * `inside` Contains markers that the change touched, but not markers with endpoints immediately adjacent to the change.
-* `overlap` Contains markers that had one or both of their endpoints surrounded by the change.s
+* `overlap` Contains markers that had one or both of their endpoints surrounded by the change.
 * `surround` Contains markers that had both endpoints surrounded by the change.
 
 ### `setExclusive (markerId, boolean)`
 
-*Exclusive* markers have a different behavior with respect to *insertions*, which are splice operations with an `oldExtent` of `{row: 0, column: 0}`. Normally, insertions are assumed to occur inside markers. Exclusive markers will prefer to interpret changes as being outside their boundaries. That is, an insertion at a markers start point will push it over, but an insertion at a marker's endpoint will not change its location.
+By default, we consider markers to be *inclusive*: that is, splices that start exactly where a marker begins **will never** move its start, and splices that end exactly where a marker ends **will always** move its end. With `setExclusive(markerId, true)`, this behavior can be changed by making the specified marker exclusive.
+
+*Exclusive* markers exhibit a different behavior with respect to splices that overlap one or both the marker's endpoints. In facts, splices that start exactly where a marker begins **will** move its start **only if the marker is not empty or the splice operation is an insertion**. On the other hand, splices that end exactly where a marker ends **will never** move its end.
 
 ### `isExclusive (markerId)`
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ This method returns an object that describes what markers were *invalidated* by 
 
 ### `setExclusive (markerId, boolean)`
 
-By default, we consider markers to be *inclusive*: that is, splices that start exactly where a marker begins **will never** move its start, and splices that end exactly where a marker ends **will always** move its end. With the `setExclusive(markerId, true)` API, these rules can be changed by making the specified marker exclusive.
+By default, we consider markers to be *inclusive*: that is, splices that start exactly where a marker begins **will not** move its start, and splices that end exactly where a marker ends **will** move its end. With the `setExclusive(markerId, true)` API, these rules can be changed by making the specified marker exclusive.
 
-*Exclusive* markers exhibit a different behavior with respect to splices that overlap one or both the marker's endpoints. In facts, splices that start exactly where a marker begins **will** move its start **only if the marker is not empty or the splice operation is an insertion**. On the other hand, splices that end exactly where a marker ends **will never** move its end.
+*Exclusive* markers exhibit a different behavior with respect to splices that overlap one or both the marker's endpoints. In facts, splices that start exactly where a marker begins **will** move its start **only if the marker is not empty or the splice operation is an insertion**. On the other hand, splices that end exactly where a marker ends **will not** move its end.
 
-A general rule applies to both cases: when a marker's start gets moved as a result of a splice, its end **will always** be moved as well.
+A general rule applies to both cases, however: when a marker's start gets moved as a result of a splice, its end **will always** be moved as well.
 
 ### `isExclusive (markerId)`
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ This method returns an object that describes what markers were *invalidated* by 
 
 ### `setExclusive (markerId, boolean)`
 
-By default, we consider markers to be *inclusive*: that is, splices that start exactly where a marker begins **will never** move its start, and splices that end exactly where a marker ends **will always** move its end. With `setExclusive(markerId, true)`, this behavior can be changed by making the specified marker exclusive.
+By default, we consider markers to be *inclusive*: that is, splices that start exactly where a marker begins **will never** move its start, and splices that end exactly where a marker ends **will always** move its end. With the `setExclusive(markerId, true)` API, these rules can be changed by making the specified marker exclusive.
 
 *Exclusive* markers exhibit a different behavior with respect to splices that overlap one or both the marker's endpoints. In facts, splices that start exactly where a marker begins **will** move its start **only if the marker is not empty or the splice operation is an insertion**. On the other hand, splices that end exactly where a marker ends **will never** move its end.
+
+A general rule applies to both cases: when a marker's start gets moved as a result of a splice, its end **will always** be moved as well.
 
 ### `isExclusive (markerId)`
 


### PR DESCRIPTION
After #5, the new "exclusive markers" behavior has become more nuanced that what's described in the documentation. This PR tries to illustrate the new exclusivity feature in greater detail, so that the docs match the actual implementation. 

@nathansobo: I think it's important that the explanation is clear and simple, so I'd ❤️ to hear your thoughts about these changes. 📝 
